### PR TITLE
Make paths public readonly on SVGParser

### DIFF
--- a/SwiftSVG/SVGParser.swift
+++ b/SwiftSVG/SVGParser.swift
@@ -70,7 +70,7 @@ public class SVGParser : NSObject, NSXMLParserDelegate {
     
     public var containerLayer: CALayer?
     public var shouldParseSinglePathOnly = false
-    internal var paths = [UIBezierPath]()
+    public private(set) var paths = [UIBezierPath]()
     
     convenience init(SVGURL: NSURL, containerLayer: CALayer? = nil, shouldParseSinglePathOnly: Bool = false) {
         


### PR DESCRIPTION
I am creating a list of bezier paths from an SVG file stored in an Xcode assets file (serialised to NSData). 

Unfortunately the SVGParser class is not publicly useful without being able to access its output. By making the paths property public I can then access the end result.

An example of my usage is as follows:

```Swift
func path() -> UIBezierPath? {
    guard let asset = NSDataAsset(name: "svg")
        else { return nil }
    
    let svg = SVGParser()
    let xml = NSXMLParser(data: asset.data)
    xml.delegate = svg
    xml.parse()
    return svg.paths.first
}
```