### PR TITLE
allow reading an SVG file with multiple paths

### DIFF
--- a/SwiftSVG.xcodeproj/project.pbxproj
+++ b/SwiftSVG.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		39B8D8B01B3C32DD009DAF60 /* UIView+SVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E25E9031AB0D4C600E8D6CB /* UIView+SVG.swift */; };
 		8AC4DBEA1CB37EA700137DC9 /* CrossPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC4DBE91CB37EA700137DC9 /* CrossPlatform.swift */; };
 		8AC4DBEB1CB37EBD00137DC9 /* CrossPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC4DBE91CB37EA700137DC9 /* CrossPlatform.swift */; };
+		AC0FA9781E4C2CF800B62B9E /* URL+SVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0FA9771E4C2CF800B62B9E /* URL+SVG.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +75,7 @@
 		9EA820851AAB649700DEE6CA /* String+SVG.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+SVG.swift"; sourceTree = "<group>"; };
 		9EA820871AAB6AD700DEE6CA /* UIBezierPath+SVG.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIBezierPath+SVG.swift"; sourceTree = "<group>"; };
 		9EB308781AC5BF350007DD82 /* SVGView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SVGView.swift; sourceTree = "<group>"; };
+		AC0FA9771E4C2CF800B62B9E /* URL+SVG.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+SVG.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -208,6 +210,7 @@
 				9EB308781AC5BF350007DD82 /* SVGView.swift */,
 				9EA820871AAB6AD700DEE6CA /* UIBezierPath+SVG.swift */,
 				9E25E9031AB0D4C600E8D6CB /* UIView+SVG.swift */,
+				AC0FA9771E4C2CF800B62B9E /* URL+SVG.swift */,
 			);
 			name = SVG;
 			sourceTree = "<group>";
@@ -394,6 +397,7 @@
 				39B8D8A61B3C32DD009DAF60 /* NSObject+Extensions.swift in Sources */,
 				39B8D8A71B3C32DD009DAF60 /* String+Subscript.swift in Sources */,
 				39B8D8A81B3C32DD009DAF60 /* String+ToHex.swift in Sources */,
+				AC0FA9781E4C2CF800B62B9E /* URL+SVG.swift in Sources */,
 				39B8D8A91B3C32DD009DAF60 /* Stack.swift in Sources */,
 				39B8D8AA1B3C32DD009DAF60 /* UIColor+Extensions.swift in Sources */,
 				8AC4DBEA1CB37EA700137DC9 /* CrossPlatform.swift in Sources */,

--- a/SwiftSVG/SVGParser.swift
+++ b/SwiftSVG/SVGParser.swift
@@ -43,7 +43,8 @@ private var tagMapping: [String: String] = [
     
     var path: UIBezierPath = UIBezierPath()
     var shapeLayer: CAShapeLayer = CAShapeLayer()
-    
+    var name: String = ""
+
     var d: String? {
         didSet {
             if let pathStringToParse = d {
@@ -60,6 +61,14 @@ private var tagMapping: [String: String] = [
             }
         }
     }
+    
+    var id: String? {
+        didSet {
+            if let nameString = id {
+                self.name = nameString
+            }
+        }
+    }
 }
 
 @objc(SVGElement) private class SVGElement: NSObject { }
@@ -71,6 +80,7 @@ open class SVGParser : NSObject, XMLParserDelegate {
     open var containerLayer: CALayer?
     open var shouldParseSinglePathOnly = false
     open fileprivate(set) var paths = [UIBezierPath]()
+    open fileprivate(set) var pathsByName: [String:UIBezierPath] = [:]
 	
 	convenience init(parser: XMLParser, containerLayer: CALayer? = nil, shouldParseSinglePathOnly: Bool = false) {
 		self.init()
@@ -115,6 +125,7 @@ open class SVGParser : NSObject, XMLParserDelegate {
                     self.containerLayer!.addSublayer(thisPath.shapeLayer)
                 }
                 self.paths.append(thisPath.path)
+                self.pathsByName[thisPath.name] = thisPath.path
                 
                 if self.shouldParseSinglePathOnly == true {
                     parser.abortParsing()

--- a/SwiftSVG/URL+SVG.swift
+++ b/SwiftSVG/URL+SVG.swift
@@ -1,0 +1,38 @@
+//
+//  URL+SVG.swift
+//  SwiftSVG
+//
+//  Copyright (c) 2017 Eric Celeste
+//  http://www.tenseg.net
+//  http://www.github.com/efc
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#if os(iOS)
+    import UIKit
+#elseif os(OSX)
+    import AppKit
+#endif
+
+extension URL {
+    public func pathsByName() -> [String: UIBezierPath] {
+        let parser = SVGParser(SVGURL: self, containerLayer: nil, shouldParseSinglePathOnly: false)
+        return parser.pathsByName
+    }
+}


### PR DESCRIPTION
This pull request provides SwiftSVG with the ability to read in an SVG file and provide named access to the individual paths in the file. The names used to access the paths will correspond to the id attributes path elements in the SVG file.

For example, given an SVG file named "shapes.svg" like this:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="100" height="100" viewBox="0, 0, 100, 100">
  <g id="Background">
    <rect x="0" y="0" width="100" height="100" fill="#FFFFFF"/>
  </g>
  <g id="shapes">
    <path d="M10,10 L90,10 L90,90 L10,90 L10,10 z" fill="#B10000" id="square"/>
    <path d="M50,90 C27.909,90 10,72.091 10,50 C10,27.909 27.909,10 50,10 C72.091,10 90,27.909 90,50 C90,72.091 72.091,90 50,90 z" fill="#B1B100" id="circle"/>
  </g>
</svg>
```
We could use this feature to read in the file like this:
```swift
let pathsByName = Bundle.main.url(forResource: "shapes", withExtension: "svg")?.pathsByName()
```
Then draw the square with:
```swift
let parsedPath = pathsByName?["square"];
parsedPath?.stroke()
```
Or draw the circle with:
```swift
let parsedPath = pathsByName?["circle"];
parsedPath?.stroke()
```
