### PR TITLE
Adds an Identifiable protocol

### DIFF
--- a/SwiftSVG.xcodeproj/project.pbxproj
+++ b/SwiftSVG.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		39B8D8A91B3C32DD009DAF60 /* Stack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E245BDA1AAE3FE000472F5A /* Stack.swift */; };
 		39B8D8AA1B3C32DD009DAF60 /* UIColor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E245B6A1AAE383200472F5A /* UIColor+Extensions.swift */; };
 		8AC4DBEA1CB37EA700137DC9 /* CrossPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC4DBE91CB37EA700137DC9 /* CrossPlatform.swift */; };
+		A738B2921FD252A9001CF969 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A738B2911FD252A9001CF969 /* Identifiable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -217,6 +218,7 @@
 		9E245B691AAE383200472F5A /* String+Subscript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Subscript.swift"; sourceTree = "<group>"; };
 		9E245B6A1AAE383200472F5A /* UIColor+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Extensions.swift"; sourceTree = "<group>"; };
 		9E245BDA1AAE3FE000472F5A /* Stack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stack.swift; sourceTree = "<group>"; };
+		A738B2911FD252A9001CF969 /* Identifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Identifiable.swift; path = Attributes/Identifiable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -376,6 +378,7 @@
 		3813ED571EFC6FCF0054ECBD /* Attributes */ = {
 			isa = PBXGroup;
 			children = (
+				A738B2911FD252A9001CF969 /* Identifiable.swift */,
 				3807CCE91F2866D900E78314 /* DelaysApplyingAttributes.swift */,
 				3807CCEC1F29940A00E78314 /* Fillable.swift */,
 				3807CCED1F29940A00E78314 /* Strokable.swift */,
@@ -695,6 +698,7 @@
 				380210241F3B881E007D236B /* Data+CacheKey.swift in Sources */,
 				380FED561F0491E200EDB255 /* SVGContainerElement.swift in Sources */,
 				38311C4D1F1738AB00E876EC /* SVGCache.swift in Sources */,
+				A738B2921FD252A9001CF969 /* Identifiable.swift in Sources */,
 				176BC9AD1EE48CE800F7B54C /* SVGCircle.swift in Sources */,
 				39B8D8AA1B3C32DD009DAF60 /* UIColor+Extensions.swift in Sources */,
 				176BC9F21EE62AF300F7B54C /* CoordinateLexer.swift in Sources */,

--- a/SwiftSVG/SVG Extensions/SVGLayer.swift
+++ b/SwiftSVG/SVG Extensions/SVGLayer.swift
@@ -39,10 +39,15 @@
  */
 public protocol SVGLayerType {
     var boundingBox: CGRect { get }
+    var identifier: String? { get }
 }
 
 public extension SVGLayerType where Self: CALayer {
-    
+
+    var identifier: String? {
+        get { return self.name }
+    }
+
     /**
      Scales a layer to aspect fit the given size.
      - Parameter rect: The `CGRect` to fit into

--- a/SwiftSVG/SVG/Attributes/Identifiable.swift
+++ b/SwiftSVG/SVG/Attributes/Identifiable.swift
@@ -1,0 +1,23 @@
+//
+//  Created by Oliver Jones on 2/12/17.
+//
+
+import Foundation
+
+public protocol Identifiable {}
+
+extension Identifiable where Self : SVGShapeElement {
+    var identityAttributes: [String : (String) -> ()] {
+        return [
+            "id": self.identify
+        ]
+    }
+
+    /**
+     Sets the identifier of the underlying `SVGLayer`.
+     - SeeAlso: CALayer's [`name`](https://developer.apple.com/documentation/quartzcore/calayer/1410879-name) property
+     */
+    func identify(identifier: String) {
+        self.svgLayer.name = identifier
+    }
+}

--- a/SwiftSVG/SVG/Elements/SVGShapeElement.swift
+++ b/SwiftSVG/SVG/Elements/SVGShapeElement.swift
@@ -38,7 +38,7 @@
 /**
  A protocol that describes an instance that stores the path as a `CAShapeLayer`
  */
-public protocol SVGShapeElement: SVGElement, Fillable, Strokable, Transformable, Stylable {
+public protocol SVGShapeElement: SVGElement, Identifiable, Fillable, Strokable, Transformable, Stylable {
     
     /**
      The `CAShapeLayer` that can draw the path data.

--- a/SwiftSVG/SVG/Parser/SVGParserSupportedElements.swift
+++ b/SwiftSVG/SVG/Parser/SVGParserSupportedElements.swift
@@ -80,6 +80,7 @@ public struct SVGParserSupportedElements {
                     "cy": returnElement.yCenter,
                     "r": returnElement.radius,
                 ]
+                returnElement.supportedAttributes.add(returnElement.identityAttributes)
                 returnElement.supportedAttributes.add(returnElement.fillAttributes)
                 returnElement.supportedAttributes.add(returnElement.strokeAttributes)
                 returnElement.supportedAttributes.add(returnElement.styleAttributes)
@@ -94,6 +95,7 @@ public struct SVGParserSupportedElements {
                     "rx": returnElement.xRadius,
                     "ry": returnElement.yRadius,
                 ]
+                returnElement.supportedAttributes.add(returnElement.identityAttributes)
                 returnElement.supportedAttributes.add(returnElement.fillAttributes)
                 returnElement.supportedAttributes.add(returnElement.strokeAttributes)
                 returnElement.supportedAttributes.add(returnElement.styleAttributes)
@@ -116,6 +118,7 @@ public struct SVGParserSupportedElements {
                     "y1": returnElement.y1,
                     "y2": returnElement.y2,
                 ]
+                returnElement.supportedAttributes.add(returnElement.identityAttributes)
                 returnElement.supportedAttributes.add(returnElement.fillAttributes)
                 returnElement.supportedAttributes.add(returnElement.strokeAttributes)
                 returnElement.supportedAttributes.add(returnElement.styleAttributes)
@@ -128,6 +131,7 @@ public struct SVGParserSupportedElements {
                     "d": returnElement.parseD,
                     "clip-rule": returnElement.clipRule
                 ]
+                returnElement.supportedAttributes.add(returnElement.identityAttributes)
                 returnElement.supportedAttributes.add(returnElement.fillAttributes)
                 returnElement.supportedAttributes.add(returnElement.strokeAttributes)
                 returnElement.supportedAttributes.add(returnElement.styleAttributes)
@@ -139,6 +143,7 @@ public struct SVGParserSupportedElements {
                 returnElement.supportedAttributes = [
                     "points": returnElement.points
                 ]
+                returnElement.supportedAttributes.add(returnElement.identityAttributes)
                 returnElement.supportedAttributes.add(returnElement.fillAttributes)
                 returnElement.supportedAttributes.add(returnElement.strokeAttributes)
                 returnElement.supportedAttributes.add(returnElement.styleAttributes)
@@ -150,6 +155,7 @@ public struct SVGParserSupportedElements {
                 returnElement.supportedAttributes = [
                     "points": returnElement.points
                 ]
+                returnElement.supportedAttributes.add(returnElement.identityAttributes)
                 returnElement.supportedAttributes.add(returnElement.fillAttributes)
                 returnElement.supportedAttributes.add(returnElement.strokeAttributes)
                 returnElement.supportedAttributes.add(returnElement.styleAttributes)
@@ -166,6 +172,7 @@ public struct SVGParserSupportedElements {
                     "x": returnElement.parseX,
                     "y": returnElement.parseY,
                 ]
+                returnElement.supportedAttributes.add(returnElement.identityAttributes)
                 returnElement.supportedAttributes.add(returnElement.fillAttributes)
                 returnElement.supportedAttributes.add(returnElement.strokeAttributes)
                 returnElement.supportedAttributes.add(returnElement.styleAttributes)


### PR DESCRIPTION
SVG/XML elements can be assigned identifiers. This PR adds an `Identifiable` protocol that `SVGShapeElement` implements.

`SVGShapeElements` with an `id` attribute will store that identifier in the CALayer’s name property.

I pretty much just hacked this together this afternoon.  Please comment and let me know if I'm doing something wrong or there are improvements I can make to improve this PR.  Keen to contribute where I can. I'm using SwiftSVG in a project and I need to be able to identify CALayers that are created from the SVGs.  I'd like to use the SVG XML element id to do that.

Thanks for considering this patch.