### PR TITLE
Remove specific SDKROOT to fix Carthage install error for MacOS

### DIFF
--- a/SwiftSVG.xcodeproj/project.pbxproj
+++ b/SwiftSVG.xcodeproj/project.pbxproj
@@ -907,7 +907,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx watchos watchsimulator appletvos appletvsimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
@@ -952,7 +951,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx watchos watchsimulator appletvos appletvsimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";


### PR DESCRIPTION
Causes Carthage to fail to install Mac version as it uses the explicitly set SDKROOT to find the framework. See:

https://github.com/Carthage/Carthage/issues/1547
