### PR TITLE
Stroke color is now applied correctly

### DIFF
--- a/SwiftSVG/SVG Extensions/SVGLayer.swift
+++ b/SwiftSVG/SVG Extensions/SVGLayer.swift
@@ -125,7 +125,7 @@ extension SVGLayer {
     override open var strokeColor: CGColor? {
         didSet {
             self.applyOnSublayers(ofType: CAShapeLayer.self) { (thisShapeLayer) in
-                thisShapeLayer.strokeColor = fillColor
+                thisShapeLayer.strokeColor = strokeColor
             }
         }
     }


### PR DESCRIPTION
Fixes #86 

This PR ensures the correct colour is applied to stroke all sublayers. However there are some caveats listed below.

1. When a stroke is provided (i.e. `lineWidth`) on the `svgLayer`, the boundingBox value will actually return a clipped rectangle since the stroke is applied along the shapes edge (from its centre)
2. Setting a stroke seems to break some SVG paths. Not sure why atm.