### PR TITLE
If don't need, does not complimenting "move" on parceD method.

### DIFF
--- a/SwiftSVG/SVG/Elements/SVGPath.swift
+++ b/SwiftSVG/SVG/Elements/SVGPath.swift
@@ -86,7 +86,10 @@ final class SVGPath: SVGShapeElement, ParsesAsynchronously, DelaysApplyingAttrib
         autoreleasepool { () -> () in
             
             let pathDPath = UIBezierPath()
-            pathDPath.move(to: CGPoint.zero)
+            
+            if (!(workingString.hasPrefix("M") || workingString.hasPrefix("m"))) {
+                pathDPath.move(to: CGPoint.zero)
+            }
             
             let parsePathClosure = {
                 var previousCommand: PreviousCommand? = nil


### PR DESCRIPTION
iOS 12 sdk(Xcode10) seems to be able to have two "move" in cgPath.
It was not so in iOS 11 and earlier.
With this difference my project did a bad action.
If do not need it, I do not think we need to add "move".


test data
`"M128.2 1447.2v-206.4h949.3v206.4h-949.3z"`

result of parseD method

iOS11 (Xcode 9.4)
```
Path 0x604000231ce0:
moveto (128.2, 1447.2)
lineto (128.2, 1240.8)
lineto (1077.5, 1240.8)
lineto (1077.5, 1447.2)
lineto (128.2, 1447.2)
closepath
```

iOS12 (Xcode 10.0)
```
Path 0x600002782be0:
moveto (0, 0)
moveto (128.2, 1447.2)
lineto (128.2, 1240.8)
lineto (1077.5, 1240.8)
lineto (1077.5, 1447.2)
lineto (128.2, 1447.2)
closepath
```