### PR TITLE
Fixed issue with cached SVGLayer

### DIFF
--- a/SwiftSVG/SVG Extensions/CALayer+SVG.swift
+++ b/SwiftSVG/SVG Extensions/CALayer+SVG.swift
@@ -70,14 +70,17 @@ public extension CALayer {
     convenience init(SVGData: Data, parser: SVGParser? = nil, completion: @escaping (SVGLayer) -> ()) {
         self.init()
         
-        if let cached = SVGCache.default[SVGData.cacheKey] {
-            DispatchQueue.main.safeAsync {
-                self.addSublayer(cached)
-            }
-            completion(cached)
-            return
-        }
-        
+		if
+			let cached = SVGCache.default[SVGData.cacheKey],
+			let cachedCopy = cached.svgLayerCopy
+		{
+			DispatchQueue.main.safeAsync {
+				self.addSublayer(cachedCopy)
+			}
+			completion(cachedCopy)
+			return
+		}
+
         let dispatchQueue = DispatchQueue(label: "com.straussmade.swiftsvg", attributes: .concurrent)
         
         dispatchQueue.async { [weak self] in


### PR DESCRIPTION
This PR fixes issue with disappearing images (ticket #127).

The issue was that when SVGLayer was read from cache, the copy of the layer was not created. 

So if same SVG icon was presented multiple times on the same screen it would be shown only once as SVGLayer got removed from previous UIViews because copies of the layer were not created (one instance of CALayer can be presented only inside one UIView)