### PR TITLE
Close path test to test last element is a close path element

### DIFF
--- a/SwiftSVGTests/ClosePathTests.swift
+++ b/SwiftSVGTests/ClosePathTests.swift
@@ -38,7 +38,7 @@ class ClosePathTests: XCTestCase {
         _ = ClosePath(parameters: [], pathType: .absolute, path:testPath)
         let lastPointAndType = testPath.cgPath.pointsAndTypes.last!
         XCTAssert(lastPointAndType.1 == .closeSubpath, "Expected .closeSubpath, got \(lastPointAndType.1)")
-        XCTAssert(lastPointAndType.0.x == 20 && lastPointAndType.0.y == -30, "Expected 20, -30, got \(lastPointAndType.0)")
+        XCTAssert(lastPointAndType.0.x.isNaN == true && lastPointAndType.0.y.isNaN == true, "Expected NaN, NaN, got \(lastPointAndType.0)")
     }
 
 }


### PR DESCRIPTION
The test was written wrong. According to the docs, a `CGPathElementType` of type `closeSubpath` does not contain any points.

https://developer.apple.com/documentation/coregraphics/cgpathelementtype/closesubpath