### PR TITLE
Multiple commands MoveTo

### DIFF
--- a/SwiftSVG/SVG/Elements/SVGPath.swift
+++ b/SwiftSVG/SVG/Elements/SVGPath.swift
@@ -90,8 +90,7 @@ final class SVGPath: SVGShapeElement, ParsesAsynchronously, DelaysApplyingAttrib
             let parsePathClosure = {
                 var previousCommand: PreviousCommand? = nil
                 for thisPathCommand in PathDLexer(pathString: workingString) {
-                    _ = thisPathCommand.execute(on: pathDPath, previousCommand: previousCommand)
-                    previousCommand = thisPathCommand
+                    previousCommand = thisPathCommand.execute(on: pathDPath, previousCommand: previousCommand)
                 }
             }
             

--- a/SwiftSVG/SVG/Elements/SVGPath.swift
+++ b/SwiftSVG/SVG/Elements/SVGPath.swift
@@ -90,7 +90,7 @@ final class SVGPath: SVGShapeElement, ParsesAsynchronously, DelaysApplyingAttrib
             let parsePathClosure = {
                 var previousCommand: PreviousCommand? = nil
                 for thisPathCommand in PathDLexer(pathString: workingString) {
-                    thisPathCommand.execute(on: pathDPath, previousCommand: previousCommand)
+                    _ = thisPathCommand.execute(on: pathDPath, previousCommand: previousCommand)
                     previousCommand = thisPathCommand
                 }
             }

--- a/SwiftSVGTests/CGPathPoints.swift
+++ b/SwiftSVGTests/CGPathPoints.swift
@@ -93,7 +93,7 @@ extension PathCommand {
     init(parameters: [Double], pathType: PathType, path: UIBezierPath, previousCommand: PreviousCommand? = nil) {
         self.init(pathType: pathType)
         self.coordinateBuffer = parameters
-        self.execute(on: path, previousCommand: previousCommand)
+        _ = self.execute(on: path, previousCommand: previousCommand)
     }
     
 }

--- a/SwiftSVGTests/PathDLexerTests.swift
+++ b/SwiftSVGTests/PathDLexerTests.swift
@@ -36,7 +36,7 @@ class PathDLexerTests: XCTestCase {
         let testString = "M80,45z"
         let testPath = UIBezierPath()
         for thisCommand in PathDLexer(pathString: testString) {
-            thisCommand.execute(on: testPath, previousCommand: nil)
+            _ = thisCommand.execute(on: testPath, previousCommand: nil)
         }
         XCTAssert(testPath.cgPath.pointsAndTypes[0].1 == .moveToPoint, "Expected MoveTo, got \(type(of: testPath.cgPath.pointsAndTypes[0].1))")
         XCTAssert(testPath.currentPoint.x == 80 && testPath.currentPoint.y == 45, "Expected {80, 45}, got \(testPath.currentPoint)")
@@ -46,7 +46,7 @@ class PathDLexerTests: XCTestCase {
         let testString = "M80-45z"
         let testPath = UIBezierPath()
         for thisCommand in PathDLexer(pathString: testString) {
-            thisCommand.execute(on: testPath, previousCommand: nil)
+            _ = thisCommand.execute(on: testPath, previousCommand: nil)
         }
         XCTAssert(testPath.cgPath.pointsAndTypes[0].1 == .moveToPoint, "Expected MoveTo, got \(type(of: testPath.cgPath.pointsAndTypes[0].1))")
         XCTAssert(testPath.currentPoint.x == 80 && testPath.currentPoint.y == -45, "Expected {80, -45}, got \(testPath.currentPoint)")
@@ -56,7 +56,7 @@ class PathDLexerTests: XCTestCase {
         let testString = "M80 -45z"
         let testPath = UIBezierPath()
         for thisCommand in PathDLexer(pathString: testString) {
-            thisCommand.execute(on: testPath, previousCommand: nil)
+            _ = thisCommand.execute(on: testPath, previousCommand: nil)
         }
         XCTAssert(testPath.cgPath.pointsAndTypes[0].1 == .moveToPoint, "Expected MoveTo, got \(type(of: testPath.cgPath.pointsAndTypes[0].1))")
         XCTAssert(testPath.currentPoint.x == 80 && testPath.currentPoint.y == -45, "Expected {80, -45}, got \(testPath.currentPoint)")
@@ -66,7 +66,7 @@ class PathDLexerTests: XCTestCase {
         let testString = "M 47 -127 z"
         let testPath = UIBezierPath()
         for thisCommand in PathDLexer(pathString: testString) {
-            thisCommand.execute(on: testPath, previousCommand: nil)
+            _ = thisCommand.execute(on: testPath, previousCommand: nil)
         }
         XCTAssert(testPath.cgPath.pointsAndTypes[0].1 == .moveToPoint, "Expected MoveTo, got \(type(of: testPath.cgPath.pointsAndTypes[0].1))")
         XCTAssert(testPath.currentPoint.x == 47 && testPath.currentPoint.y == -127, "Expected {47, -127}, got \(testPath.currentPoint)")
@@ -76,7 +76,7 @@ class PathDLexerTests: XCTestCase {
         let testString = "M30-40L20,50z M10,20L80,90z"
         let testPath = UIBezierPath()
         for thisCommand in PathDLexer(pathString: testString) {
-            thisCommand.execute(on: testPath, previousCommand: nil)
+            _ = thisCommand.execute(on: testPath, previousCommand: nil)
         }
         XCTAssert(testPath.cgPath.pointsAndTypes[2].1 == .closeSubpath, "Expected .closeSubpath, got \(String(describing: testPath.cgPath.pointsAndTypes[2].1))")
         XCTAssert(testPath.cgPath.pointsAndTypes.last!.1 == .closeSubpath, "Expected .closeSubpath, got \(String(describing: testPath.cgPath.pointsAndTypes.last!.1))")
@@ -86,7 +86,7 @@ class PathDLexerTests: XCTestCase {
         let testString = "m193.2 162.44c4.169 0 8.065 0.631 12.327 0.631 3.391 0 7.062-0.404 10.427 0 0.881 0.105 3.056 0.187 3.793 0.633 1.551 0.939 1.013 0.261 1.265 2.527 0.164 1.476 0 3.078 0 4.565 0 1.211-0.826 6.618-0.315 7.129 1.238 1.238 5.366 2.607 7.269 3.476 2.513 1.146 4.488 2.562 6.952 3.793 2.435 1.217 5.177 1.804 4.426 4.424-0.364 1.271-1.808 2.668-2.529 3.793-0.438 0.684-2.528 3.339-2.528 4.109 0 0.606-13.593-2.429-15.17-2.846-2.26-0.598-5.387-0.692-6.004-3.16-0.631-2.525-0.661-5.73-0.949-8.217-0.358-3.095 1.059-6.32-2.844-6.32-2.102 0-5.384 0.628-7.269-0.316-1.008-0.505-2.737 0.105-3.476-0.632-0.979-0.977-1.59-1.802-2.214-3.478-1.23-3.25-2.25-6.73-3.17-10.1"
         let testPath = UIBezierPath()
         for thisCommand in PathDLexer(pathString: testString) {
-            thisCommand.execute(on: testPath, previousCommand: nil)
+            _ = thisCommand.execute(on: testPath, previousCommand: nil)
         }
     }
     
@@ -94,10 +94,23 @@ class PathDLexerTests: XCTestCase {
         let testString = "M1.5.5z"
         let testPath = UIBezierPath()
         for thisCommand in PathDLexer(pathString: testString) {
-            thisCommand.execute(on: testPath, previousCommand: nil)
+            _ = thisCommand.execute(on: testPath, previousCommand: nil)
         }
         XCTAssert(testPath.cgPath.pointsAndTypes[0].1 == .moveToPoint, "Expected MoveTo, got \(type(of: testPath.cgPath.pointsAndTypes[0].1))")
         XCTAssert(testPath.currentPoint.x == 1.5 && testPath.currentPoint.y == 0.5, "Expected {1.5, 0.5}, got \(testPath.currentPoint)")
+    }
+    
+    func testMultipleMoveTo() {
+        let testString = "m40,40 40,0 m0,40 0,-40"
+        let testPath = UIBezierPath()
+        var previousCommand: PreviousCommand? = nil
+        for thisCommand in PathDLexer(pathString: testString) {
+            previousCommand = thisCommand.execute(on: testPath, previousCommand: previousCommand)
+        }
+        XCTAssert(testPath.cgPath.pointsAndTypes[0].1 == .moveToPoint, "Expected MoveTo, got \(type(of: testPath.cgPath.pointsAndTypes[0].1))")
+        XCTAssert(testPath.cgPath.pointsAndTypes[1].1 == .addLineToPoint, "Expected addLineToPoint, got \(type(of: testPath.cgPath.pointsAndTypes[1].1))")
+        XCTAssert(testPath.cgPath.pointsAndTypes[2].1 == .moveToPoint, "Expected moveToPoint, got \(type(of: testPath.cgPath.pointsAndTypes[2].1))")
+        XCTAssert(testPath.cgPath.pointsAndTypes[3].1 == .addLineToPoint, "Expected addLineToPoint, got \(type(of: testPath.cgPath.pointsAndTypes[3].1))")
     }
 }
 


### PR DESCRIPTION
Hi! I found an issue. If we have a path d="m50,50 200,0 m0,200 -200,0" algorithm draws three lines instead of two like it should do because the third command MoveTo is explicit and cannot be treated like LineTo. I fixed this by returning the previous command from the function execute, as it may change inside the function. Also, I changed Unit Tests and created a new one for this case.